### PR TITLE
Add Status DbSize support for apiserver etcd metrics

### DIFF
--- a/pkg/drivers/dqlite/dqlite.go
+++ b/pkg/drivers/dqlite/dqlite.go
@@ -1,9 +1,12 @@
+//go:build dqlite
 // +build dqlite
 
 package dqlite
 
 import (
 	"context"
+	crypto_tls "crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -11,8 +14,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	crypto_tls "crypto/tls"
-	"crypto/x509"
 
 	"github.com/canonical/go-dqlite"
 	"github.com/canonical/go-dqlite/app"

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Rican7/retry/jitter"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,6 +82,7 @@ type Generic struct {
 	InsertSQL             string
 	FillSQL               string
 	InsertLastInsertIDSQL string
+	GetSizeSQL            string
 	Retry                 ErrRetry
 	TranslateErr          TranslateErr
 }
@@ -416,4 +418,11 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 
 	id, err = d.queryInt64(ctx, d.InsertSQL, key, cVal, dVal, createRevision, previousRevision, ttl, value, prevValue)
 	return id, err
+}
+
+func (d *Generic) GetSize(ctx context.Context) (int64, error) {
+	if d.GetSizeSQL == "" {
+		return 0, errors.New("driver does not support size reporting")
+	}
+	return d.queryInt64(ctx, d.GetSizeSQL)
 }

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package sqlite
@@ -63,6 +64,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		}
 		return err
 	}
+	dialect.GetSizeSQL = `SELECT sum(pgsize) FROM dbstat`
 
 	// this is the first SQL that will be executed on a new DB conn so
 	// loop on failure here because in the case of dqlite it could still be initializing

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -17,6 +17,7 @@ type Log interface {
 	Watch(ctx context.Context, prefix string) <-chan []*server.Event
 	Count(ctx context.Context, prefix string) (int64, int64, error)
 	Append(ctx context.Context, event *server.Event) (int64, error)
+	DbSize(ctx context.Context) (int64, error)
 }
 
 type LogStructured struct {
@@ -359,4 +360,8 @@ func filter(events []*server.Event, rev int64) []*server.Event {
 	}
 
 	return events
+}
+
+func (l *LogStructured) DbSize(ctx context.Context) (int64, error) {
+	return l.log.DbSize(ctx)
 }

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -39,6 +39,7 @@ type Dialect interface {
 	SetCompactRevision(ctx context.Context, revision int64) error
 	Fill(ctx context.Context, revision int64) error
 	IsFill(key string) bool
+	GetSize(ctx context.Context) (int64, error)
 }
 
 func (s *SQLLog) Start(ctx context.Context) (err error) {
@@ -516,4 +517,8 @@ func scan(rows *sql.Rows, rev *int64, compact *int64, event *server.Event) error
 
 	*compact = c.Int64
 	return nil
+}
+
+func (s *SQLLog) DbSize(ctx context.Context) (int64, error) {
+	return s.d.GetSize(ctx)
 }

--- a/pkg/server/dbsize.go
+++ b/pkg/server/dbsize.go
@@ -1,0 +1,7 @@
+package server
+
+import "context"
+
+func (l *LimitedServer) dbSize(ctx context.Context) (int64, error) {
+	return l.backend.DbSize(ctx)
+}

--- a/pkg/server/maintenance.go
+++ b/pkg/server/maintenance.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+var _ etcdserverpb.MaintenanceServer = (*KVServerBridge)(nil)
+
+func (s *KVServerBridge) Alarm(context.Context, *etcdserverpb.AlarmRequest) (*etcdserverpb.AlarmResponse, error) {
+	return nil, fmt.Errorf("alarm is not supported")
+}
+
+func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusRequest) (*etcdserverpb.StatusResponse, error) {
+	size, err := s.limited.dbSize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &etcdserverpb.StatusResponse{
+		Header: &etcdserverpb.ResponseHeader{},
+		DbSize: size,
+	}, nil
+}
+
+func (s *KVServerBridge) Defragment(context.Context, *etcdserverpb.DefragmentRequest) (*etcdserverpb.DefragmentResponse, error) {
+	return nil, fmt.Errorf("defragment is not supported")
+}
+
+func (s *KVServerBridge) Hash(context.Context, *etcdserverpb.HashRequest) (*etcdserverpb.HashResponse, error) {
+	return nil, fmt.Errorf("hash is not supported")
+}
+
+func (s *KVServerBridge) HashKV(context.Context, *etcdserverpb.HashKVRequest) (*etcdserverpb.HashKVResponse, error) {
+	return nil, fmt.Errorf("hash kv is not supported")
+}
+
+func (s *KVServerBridge) Snapshot(*etcdserverpb.SnapshotRequest, etcdserverpb.Maintenance_SnapshotServer) error {
+	return fmt.Errorf("snapshot is not supported")
+}
+
+func (s *KVServerBridge) MoveLeader(context.Context, *etcdserverpb.MoveLeaderRequest) (*etcdserverpb.MoveLeaderResponse, error) {
+	return nil, fmt.Errorf("move leader is not supported")
+}
+
+func (s *KVServerBridge) Downgrade(context.Context, *etcdserverpb.DowngradeRequest) (*etcdserverpb.DowngradeResponse, error) {
+	return nil, fmt.Errorf("downgrade is not supported")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,6 +33,7 @@ func (k *KVServerBridge) Register(server *grpc.Server) {
 	etcdserverpb.RegisterLeaseServer(server, k)
 	etcdserverpb.RegisterWatchServer(server, k)
 	etcdserverpb.RegisterKVServer(server, k)
+	etcdserverpb.RegisterMaintenanceServer(server, k)
 
 	hsrv := health.NewServer()
 	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -20,6 +20,7 @@ type Backend interface {
 	Count(ctx context.Context, prefix string) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
 	Watch(ctx context.Context, key string, revision int64) <-chan []*Event
+	DbSize(ctx context.Context) (int64, error)
 }
 
 type KeyValue struct {


### PR DESCRIPTION
This cherry-picks changes from [0], only for the parts related to sqlite/dqlite

[0]: https://github.com/k3s-io/kine/commit/92fcaea9111e2435227d5c70c3c2dc6d91fc82e7