### PR TITLE
Start test for Watch operation

### DIFF
--- a/test/util_test.go
+++ b/test/util_test.go
@@ -12,6 +12,15 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+var (
+	// testWatchEventPollTimeout is the timeout for waiting to receive an event.
+	testWatchEventPollTimeout = 50 * time.Millisecond
+
+	// testWatchEventIdleTimeout is the amount of time to wait to ensure that no events
+	// are received when they should not.
+	testWatchEventIdleTimeout = 100 * time.Millisecond
+)
+
 // newKine spins up a new instance of kine. it also registers cleanup functions for temporary data
 //
 // newKine is currently hardcoded to using sqlite and a unix socket listener, but might be extended in the future

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -28,7 +28,7 @@ func TestWatch(t *testing.T) {
 
 	t.Run("ReceiveNothingUntilActivity", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+		g.Consistently(watchCh, testWatchEventIdleTimeout).ShouldNot(Receive())
 	})
 
 	t.Run("Create", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestWatch(t *testing.T) {
 		// receive event
 		t.Run("Receive", func(t *testing.T) {
 			g := NewWithT(t)
-			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+			g.Eventually(watchCh, testWatchEventPollTimeout).Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
 				g.Expect(v.Events).To(HaveLen(1))
 				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
 				g.Expect(v.Events[0].PrevKv).To(BeNil())
@@ -64,7 +64,7 @@ func TestWatch(t *testing.T) {
 
 		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
 			g := NewWithT(t)
-			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+			g.Consistently(watchCh, testWatchEventIdleTimeout).ShouldNot(Receive())
 		})
 	})
 
@@ -87,7 +87,7 @@ func TestWatch(t *testing.T) {
 			g := NewWithT(t)
 
 			// receive event
-			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+			g.Eventually(watchCh, testWatchEventPollTimeout).Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
 				g.Expect(v.Events).To(HaveLen(1))
 				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
 				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
@@ -107,7 +107,7 @@ func TestWatch(t *testing.T) {
 
 		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
 			g := NewWithT(t)
-			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+			g.Consistently(watchCh, testWatchEventIdleTimeout).ShouldNot(Receive())
 		})
 	})
 
@@ -130,7 +130,7 @@ func TestWatch(t *testing.T) {
 			g := NewWithT(t)
 
 			// receive event
-			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+			g.Eventually(watchCh, testWatchEventPollTimeout).Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
 				g.Expect(v.Events).To(HaveLen(1))
 				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypeDelete))
 				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
@@ -151,7 +151,7 @@ func TestWatch(t *testing.T) {
 
 		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
 			g := NewWithT(t)
-			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+			g.Consistently(watchCh, testWatchEventIdleTimeout).ShouldNot(Receive())
 		})
 	})
 
@@ -161,7 +161,7 @@ func TestWatch(t *testing.T) {
 		t.Run("Receive", func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Eventually(watchAfterDeleteCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+			g.Eventually(watchAfterDeleteCh, testWatchEventPollTimeout).Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
 				// receive 2 events
 				g.Expect(v.Events).To(HaveLen(2))
 
@@ -194,7 +194,7 @@ func TestWatch(t *testing.T) {
 
 		t.Run("OtherWatcherIdle", func(t *testing.T) {
 			g := NewWithT(t)
-			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+			g.Consistently(watchCh, testWatchEventIdleTimeout).ShouldNot(Receive())
 		})
 	})
 }

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -1,0 +1,107 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestWatch is unit testing for the Watch operation.
+func TestWatch(t *testing.T) {
+	ctx := context.Background()
+	client := newKine(t)
+
+	key := "testKey"
+	value := "testValue"
+	watchCh := client.Watch(ctx, key)
+
+	t.Run("ReceiveNothingUntilActivity", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+	})
+
+	var latestRevision int64
+
+	t.Run("Create", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// create a key
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpPut(key, value)).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		// receive event
+		t.Run("Receive", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+				g.Expect(v.Events).To(HaveLen(1))
+				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
+				g.Expect(v.Events[0].PrevKv).To(BeNil())
+				g.Expect(v.Events[0].Kv.Key).To(Equal([]byte(key)))
+				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(value)))
+				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
+
+				latestRevision = v.Events[0].Kv.ModRevision
+
+				return true
+			})))
+		})
+
+		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		g := NewWithT(t)
+
+		newValue := "testUpdatedValue"
+		// update key
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", latestRevision)).
+				Then(clientv3.OpPut(key, string(newValue))).
+				Else(clientv3.OpGet(key)).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		t.Run("Receive", func(t *testing.T) {
+			g := NewWithT(t)
+
+			// receive event
+			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+				g.Expect(v.Events).To(HaveLen(1))
+				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
+				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
+				g.Expect(v.Events[0].PrevKv.Value).To(Equal([]byte(value)))
+				g.Expect(v.Events[0].PrevKv.ModRevision).To(Equal(latestRevision))
+
+				g.Expect(v.Events[0].Kv.Key).To(Equal([]byte(key)))
+				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(newValue)))
+				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
+				g.Expect(v.Events[0].Kv.ModRevision).To(BeNumerically(">", latestRevision))
+
+				latestRevision = v.Events[0].Kv.ModRevision
+
+				return true
+			})))
+		})
+
+		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+		})
+	})
+}

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -13,16 +13,23 @@ func TestWatch(t *testing.T) {
 	ctx := context.Background()
 	client := newKine(t)
 
-	key := "testKey"
-	value := "testValue"
+	var (
+		revAfterCreate int64
+		revAfterUpdate int64
+		revAfterDelete int64
+
+		key          = "testKey"
+		value        = "testValue"
+		updatedValue = "testUpdatedValue"
+	)
+
+	// start watching for events on key
 	watchCh := client.Watch(ctx, key)
 
 	t.Run("ReceiveNothingUntilActivity", func(t *testing.T) {
 		g := NewWithT(t)
 		g.Consistently(watchCh, "100ms").ShouldNot(Receive())
 	})
-
-	var latestRevision int64
 
 	t.Run("Create", func(t *testing.T) {
 		g := NewWithT(t)
@@ -49,7 +56,7 @@ func TestWatch(t *testing.T) {
 				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(value)))
 				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
 
-				latestRevision = v.Events[0].Kv.ModRevision
+				revAfterCreate = v.Events[0].Kv.ModRevision
 
 				return true
 			})))
@@ -64,12 +71,11 @@ func TestWatch(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		g := NewWithT(t)
 
-		newValue := "testUpdatedValue"
 		// update key
 		{
 			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", latestRevision)).
-				Then(clientv3.OpPut(key, string(newValue))).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", revAfterCreate)).
+				Then(clientv3.OpPut(key, string(updatedValue))).
 				Else(clientv3.OpGet(key)).
 				Commit()
 
@@ -86,20 +92,107 @@ func TestWatch(t *testing.T) {
 				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
 				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
 				g.Expect(v.Events[0].PrevKv.Value).To(Equal([]byte(value)))
-				g.Expect(v.Events[0].PrevKv.ModRevision).To(Equal(latestRevision))
+				g.Expect(v.Events[0].PrevKv.ModRevision).To(Equal(revAfterCreate))
 
 				g.Expect(v.Events[0].Kv.Key).To(Equal([]byte(key)))
-				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(newValue)))
+				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(updatedValue)))
 				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
-				g.Expect(v.Events[0].Kv.ModRevision).To(BeNumerically(">", latestRevision))
+				g.Expect(v.Events[0].Kv.ModRevision).To(BeNumerically(">", revAfterCreate))
 
-				latestRevision = v.Events[0].Kv.ModRevision
+				revAfterUpdate = v.Events[0].Kv.ModRevision
 
 				return true
 			})))
 		})
 
 		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+		})
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// delete key
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", revAfterUpdate)).
+				Then(clientv3.OpDelete(key)).
+				Else(clientv3.OpGet(key)).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		t.Run("Receive", func(t *testing.T) {
+			g := NewWithT(t)
+
+			// receive event
+			g.Eventually(watchCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+				g.Expect(v.Events).To(HaveLen(1))
+				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypeDelete))
+				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
+				g.Expect(v.Events[0].PrevKv.Value).To(Equal([]byte(updatedValue)))
+				g.Expect(v.Events[0].PrevKv.ModRevision).To(Equal(revAfterUpdate))
+
+				g.Expect(v.Events[0].Kv).NotTo(BeNil())
+				g.Expect(v.Events[0].Kv.Key).To(Equal([]byte(key)))
+				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(updatedValue)))
+				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
+				g.Expect(v.Events[0].Kv.ModRevision).To(BeNumerically(">", revAfterUpdate))
+
+				revAfterDelete = v.Events[0].Kv.ModRevision
+
+				return true
+			})))
+		})
+
+		t.Run("ReceiveNothingUntilNewActivity", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
+		})
+	})
+
+	t.Run("StartRevision", func(t *testing.T) {
+		watchAfterDeleteCh := client.Watch(ctx, key, clientv3.WithRev(revAfterUpdate))
+
+		t.Run("Receive", func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Eventually(watchAfterDeleteCh, "50ms").Should(Receive(Satisfy(func(v clientv3.WatchResponse) bool {
+				// receive 2 events
+				g.Expect(v.Events).To(HaveLen(2))
+
+				// receive update event
+				g.Expect(v.Events[0].Type).To(Equal(clientv3.EventTypePut))
+				g.Expect(v.Events[0].PrevKv).NotTo(BeNil())
+				g.Expect(v.Events[0].PrevKv.Value).To(Equal([]byte(value)))
+				g.Expect(v.Events[0].PrevKv.ModRevision).To(Equal(revAfterCreate))
+
+				g.Expect(v.Events[0].Kv.Key).To(Equal([]byte(key)))
+				g.Expect(v.Events[0].Kv.Value).To(Equal([]byte(updatedValue)))
+				g.Expect(v.Events[0].Kv.Version).To(Equal(int64(0)))
+				g.Expect(v.Events[0].Kv.ModRevision).To(Equal(revAfterUpdate))
+
+				// receive delete event
+				g.Expect(v.Events[1].Type).To(Equal(clientv3.EventTypeDelete))
+				g.Expect(v.Events[1].PrevKv).NotTo(BeNil())
+				g.Expect(v.Events[1].PrevKv.Value).To(Equal([]byte(updatedValue)))
+				g.Expect(v.Events[1].PrevKv.ModRevision).To(Equal(revAfterUpdate))
+
+				g.Expect(v.Events[1].Kv).NotTo(BeNil())
+				g.Expect(v.Events[1].Kv.Key).To(Equal([]byte(key)))
+				g.Expect(v.Events[1].Kv.Value).To(Equal([]byte(updatedValue)))
+				g.Expect(v.Events[1].Kv.Version).To(Equal(int64(0)))
+				g.Expect(v.Events[1].Kv.ModRevision).To(Equal(revAfterDelete))
+
+				return true
+			})))
+		})
+
+		t.Run("OtherWatcherIdle", func(t *testing.T) {
 			g := NewWithT(t)
 			g.Consistently(watchCh, "100ms").ShouldNot(Receive())
 		})


### PR DESCRIPTION
### Summary

Add an initial test for Watch operations. Sets up kine, starts a watcher and verifies received events.

The tests are written in a way that is easy to see the diff in case of an error. It is possible that more fields of the response should be verified

### Notes

This is only testing basic things (e.g. create, update and delete events are received).