### PR TITLE
Added update tests and benchmarks

### DIFF
--- a/test/update_test.go
+++ b/test/update_test.go
@@ -35,7 +35,7 @@ func TestUpdate(t *testing.T) {
 			g.Expect(resp.Kvs).To(HaveLen(1))
 			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateNewKey")))
 			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
-			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically("==", resp.Kvs[0].CreateRevision))
+			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(resp.Kvs[0].CreateRevision)))
 		}
 	})
 
@@ -52,6 +52,8 @@ func TestUpdate(t *testing.T) {
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeTrue())
+			g.Expect(resp.Responses).To(HaveLen(1))
+			g.Expect(resp.Responses[0].GetResponsePut()).NotTo(BeNil())
 			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
 		}
 
@@ -90,6 +92,8 @@ func TestUpdate(t *testing.T) {
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeTrue())
+			g.Expect(resp.Responses).To(HaveLen(1))
+			g.Expect(resp.Responses[0].GetResponsePut()).NotTo(BeNil())
 			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
 		}
 
@@ -113,7 +117,8 @@ func TestUpdate(t *testing.T) {
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeFalse())
-
+			g.Expect(resp.Responses).To(HaveLen(1))
+			g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
 		}
 
 	})

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -1,0 +1,145 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestUpdate is unit testing for the update operation.
+func TestUpdate(t *testing.T) {
+	ctx := context.Background()
+	client := newKine(t)
+
+	// Testing that update can create a new key if ModRevision is 0
+	t.Run("UpdateNewKey", func(t *testing.T) {
+		g := NewWithT(t)
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateNewKey"), "=", 0)).
+				Then(clientv3.OpPut("updateNewKey", "testValue")).
+				Else(clientv3.OpGet("updateNewKey", clientv3.WithRange(""))).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		{
+			resp, err := client.Get(ctx, "updateNewKey", clientv3.WithRange(""))
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(1))
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateNewKey")))
+			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
+			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically("==", resp.Kvs[0].CreateRevision))
+		}
+	})
+
+	t.Run("UpdateExisting", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var lastModRev int64
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateExistingKey"), "=", 0)).
+				Then(clientv3.OpPut("updateExistingKey", "testValue1")).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
+		}
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateExistingKey"), "=", lastModRev)).
+				Then(clientv3.OpPut("updateExistingKey", "testValue2")).
+				Else(clientv3.OpGet("updateExistingKey", clientv3.WithRange(""))).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		{
+			resp, err := client.Get(ctx, "updateExistingKey", clientv3.WithRange(""))
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(1))
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateExistingKey")))
+			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
+			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
+		}
+	})
+
+	// Trying to update an old revision(in compare) should fail
+	t.Run("UpdateOldRevisionFails", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var lastModRev int64
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateOldRevKey"), "=", 0)).
+				Then(clientv3.OpPut("updateOldRevKey", "testValue1")).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
+		}
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateOldRevKey"), "=", lastModRev)).
+				Then(clientv3.OpPut("updateOldRevKey", "testValue2")).
+				Else(clientv3.OpGet("updateOldRevKey", clientv3.WithRange(""))).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		{
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision("updateOldRevKey"), "=", lastModRev)).
+				Then(clientv3.OpPut("updateOldRevKey", "testValue2")).
+				Else(clientv3.OpGet("updateOldRevKey", clientv3.WithRange(""))).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeFalse())
+
+		}
+
+	})
+
+}
+
+// BenchmarkUpdate is a benchmark for the Update operation.
+func BenchmarkUpdate(b *testing.B) {
+	ctx := context.Background()
+	client := newKine(b)
+
+	g := NewWithT(b)
+
+	var lastModRev int64 = 0
+
+	for i := 0; i < b.N; i++ {
+		value := fmt.Sprintf("value-%d", i)
+		resp, err := client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision("benchKey"), "=", lastModRev)).
+			Then(clientv3.OpPut("benchKey", value)).
+			Else(clientv3.OpGet("benchKey", clientv3.WithRange(""))).
+			Commit()
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Succeeded).To(BeTrue())
+		lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
+
+	}
+}


### PR DESCRIPTION
### Summary

Updates in Kine only work with MOD_REV and EQUAL comparison. Updates with a mod revision  0 can create a key, and the respectful revision increases should be provided by the requester.

These tests verify that 
* a new key can be created through an update by using mod revision 0
* a created key can be updated and the revision is updated 
* trying to update a key in an old revision fails

The benchmark updates a single key for N times.

Open to suggestions, thanks.