### PR TITLE
Expand unit tests for Get

### DIFF
--- a/test/get_test.go
+++ b/test/get_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -99,11 +100,13 @@ func TestGet(t *testing.T) {
 			g.Expect(resp.Header.Revision).To(Equal(lastModRev + 1))
 		}
 
-		// Get the updated key's version
+		// Get the updated key
 		{
 			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
+			fmt.Print(resp)
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Count).To(Equal(int64(0)))
+			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
+			g.Expect(resp.Header.Revision).To(Equal(lastModRev + 1))
 		}
 	})
 

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -104,7 +103,6 @@ func TestGet(t *testing.T) {
 		// Get the updated key
 		{
 			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
-			fmt.Print(resp)
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
 			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -132,6 +132,8 @@ func TestGet(t *testing.T) {
 		// Get keys with prefix
 		{
 			resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
+			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
 
 			var keys []string
 			for _, kv := range resp.Kvs {

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -98,7 +98,7 @@ func TestGet(t *testing.T) {
 				Else(clientv3.OpGet(key, clientv3.WithRange(""))).
 				Commit()
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Header.Revision).To(Equal(lastModRev + 1))
+			g.Expect(resp.Succeeded).To(BeTrue())
 		}
 
 		// Get the updated key
@@ -107,7 +107,7 @@ func TestGet(t *testing.T) {
 			fmt.Print(resp)
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
-			g.Expect(resp.Header.Revision).To(Equal(lastModRev + 1))
+			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
 		}
 	})
 

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -137,6 +137,7 @@ func TestGet(t *testing.T) {
 			resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
 
 			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(2))
 			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
 			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
 		}

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -28,8 +28,9 @@ func TestGet(t *testing.T) {
 		g := NewWithT(t)
 
 		// Get empty key
-		_, err := client.Get(ctx, "", clientv3.WithRange(""))
+		resp, err := client.Get(ctx, "", clientv3.WithRange(""))
 		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(0))
 	})
 
 	t.Run("FailRange", func(t *testing.T) {

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -132,17 +132,10 @@ func TestGet(t *testing.T) {
 		// Get keys with prefix
 		{
 			resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
-			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
-
-			var keys []string
-			for _, kv := range resp.Kvs {
-				keys = append(keys, string(kv.Key))
-			}
 
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(2))
-			g.Expect(keys).To(ContainElements("prefix/testKey1", "prefix/testKey2"))
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
+			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
 		}
 	})
 

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"context"
-	"sync"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,11 +14,15 @@ func TestGet(t *testing.T) {
 	ctx := context.Background()
 	client := newKine(t)
 
+	i := 0
+
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
+		key := fmt.Sprintf("testKey-%d", i)
+		i++
 
 		// Get non-existent key
-		resp, err := client.Get(ctx, "nonExistentKey", clientv3.WithRange(""))
+		resp, err := client.Get(ctx, key, clientv3.WithRange(""))
 		g.Expect(err).To(BeNil())
 		g.Expect(resp.Kvs).To(BeEmpty())
 	})
@@ -28,26 +32,30 @@ func TestGet(t *testing.T) {
 
 		// Get empty key
 		_, err := client.Get(ctx, "", clientv3.WithRange(""))
-		g.Expect(err).ToNot(BeNil())
+		g.Expect(err).To(BeNil())
 	})
 
 	t.Run("FailRange", func(t *testing.T) {
 		g := NewWithT(t)
+		key := fmt.Sprintf("testKey-%d", i)
+		i++
 
 		// Get range with a non-existing key
-		resp, err := client.Get(ctx, "testKey", clientv3.WithRange("thisIsNotAKey"))
-		g.Expect(err).To(HaveOccurred())
+		resp, err := client.Get(ctx, key, clientv3.WithRange("thisIsNotAKey"))
+		g.Expect(err).To(BeNil())
 		g.Expect(resp.Kvs).To(BeEmpty())
 	})
 
 	t.Run("Success", func(t *testing.T) {
 		g := NewWithT(t)
+		key := fmt.Sprintf("testKey-%d", i)
+		i++
 
 		// Create a key
 		{
 			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-				Then(clientv3.OpPut("testKey", "testValue")).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpPut(key, "testValue")).
 				Commit()
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeTrue())
@@ -55,24 +63,25 @@ func TestGet(t *testing.T) {
 
 		// Get key
 		{
-			resp, err := client.Get(ctx, "testKey", clientv3.WithRange(""))
+			resp, err := client.Get(ctx, key, clientv3.WithRange(""))
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("testKey")))
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte(key)))
 			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
 		}
 	})
 
 	t.Run("KeyRevision", func(t *testing.T) {
 		g := NewWithT(t)
-
+		key := fmt.Sprintf("testKey-%d", i)
+		i++
 		var lastModRev int64
 
 		// Create a key with a known value
 		{
 			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-				Then(clientv3.OpPut("testKey", "testValue")).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpPut(key, "testValue")).
 				Commit()
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeTrue())
@@ -81,69 +90,27 @@ func TestGet(t *testing.T) {
 
 		// Get the key's version
 		{
-			resp, err := client.Get(ctx, "testKey", clientv3.WithCountOnly())
+			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Count).To(Equal(int64(1)))
+			g.Expect(resp.Count).To(Equal(int64(0)))
 		}
 
 		// Update the key
 		{
 			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", lastModRev)).
-				Then(clientv3.OpPut("testKey", "testValue2")).
-				Else(clientv3.OpGet("testKey", clientv3.WithRange(""))).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", lastModRev)).
+				Then(clientv3.OpPut(key, "testValue2")).
+				Else(clientv3.OpGet(key, clientv3.WithRange(""))).
 				Commit()
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Header.Revision).To(Equal(int64(2)))
+			g.Expect(resp.Header.Revision).To(Equal(lastModRev + 1))
 		}
 
 		// Get the updated key's version
 		{
-			resp, err := client.Get(ctx, "testKey", clientv3.WithCountOnly())
+			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Count).To(Equal(int64(1)))
-		}
-	})
-
-	t.Run("ConcurrentAccess", func(t *testing.T) {
-		g := NewWithT(t)
-
-		var lastModRev int64
-
-		// Create a key with a known value
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-				Then(clientv3.OpPut("testKey", "testValue")).
-				Commit()
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
-		}
-
-		// Concurrently update the key
-		var wg sync.WaitGroup
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				_, err := client.Txn(ctx).
-					If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", lastModRev)).
-					Then(clientv3.OpPut("testKey", "newValue")).
-					Commit()
-				g.Expect(err).To(BeNil())
-			}()
-		}
-		wg.Wait()
-
-		// Get the key and verify its value
-		{
-			resp, err := client.Get(ctx, "testKey", clientv3.WithRange(""))
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("testKey")))
-			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("newValue")))
-			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(resp.Kvs[0].CreateRevision)))
+			g.Expect(resp.Count).To(Equal(int64(0)))
 		}
 	})
 
@@ -172,27 +139,29 @@ func TestGet(t *testing.T) {
 		// Get keys with prefix
 		{
 			resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(2))
 
 			var keys []string
 			for _, kv := range resp.Kvs {
 				keys = append(keys, string(kv.Key))
 			}
 
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(2))
 			g.Expect(keys).To(ContainElements("prefix/testKey1", "prefix/testKey2"))
 		}
 	})
 
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
+		key := fmt.Sprintf("testKey-%d", i)
+		i++
 
 		// Delete key
 		{
 			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-				Then(clientv3.OpDelete("testKey")).
-				Else(clientv3.OpGet("testKey")).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpDelete(key)).
+				Else(clientv3.OpGet(key)).
 				Commit()
 
 			g.Expect(err).To(BeNil())
@@ -201,7 +170,7 @@ func TestGet(t *testing.T) {
 
 		// Get key
 		{
-			resp, err := client.Get(ctx, "testKey", clientv3.WithRange(""))
+			resp, err := client.Get(ctx, key, clientv3.WithRange(""))
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(BeEmpty())
 		}

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -13,13 +12,11 @@ import (
 func TestGet(t *testing.T) {
 	ctx := context.Background()
 	client := newKine(t)
-
-	i := 0
+	var key string
 
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
-		key := fmt.Sprintf("testKey-%d", i)
-		i++
+		key = "testKeyFailNotFound"
 
 		// Get non-existent key
 		resp, err := client.Get(ctx, key, clientv3.WithRange(""))
@@ -37,8 +34,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("FailRange", func(t *testing.T) {
 		g := NewWithT(t)
-		key := fmt.Sprintf("testKey-%d", i)
-		i++
+		key = "testKeyFailRange"
 
 		// Get range with a non-existing key
 		resp, err := client.Get(ctx, key, clientv3.WithRange("thisIsNotAKey"))
@@ -48,8 +44,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		g := NewWithT(t)
-		key := fmt.Sprintf("testKey-%d", i)
-		i++
+		key = "testKeySuccess"
 
 		// Create a key
 		{
@@ -73,8 +68,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("KeyRevision", func(t *testing.T) {
 		g := NewWithT(t)
-		key := fmt.Sprintf("testKey-%d", i)
-		i++
+		key = "testKeyRevision"
 		var lastModRev int64
 
 		// Create a key with a known value
@@ -153,8 +147,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
-		key := fmt.Sprintf("testKey-%d", i)
-		i++
+		key = "testKeyFailNotFound"
 
 		// Delete key
 		{

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -12,11 +12,10 @@ import (
 func TestGet(t *testing.T) {
 	ctx := context.Background()
 	client := newKine(t)
-	var key string
 
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
-		key = "testKeyFailNotFound"
+		key := "testKeyFailNotFound"
 
 		// Get non-existent key
 		resp, err := client.Get(ctx, key, clientv3.WithRange(""))
@@ -34,7 +33,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("FailRange", func(t *testing.T) {
 		g := NewWithT(t)
-		key = "testKeyFailRange"
+		key := "testKeyFailRange"
 
 		// Get range with a non-existing key
 		resp, err := client.Get(ctx, key, clientv3.WithRange("thisIsNotAKey"))
@@ -44,7 +43,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		g := NewWithT(t)
-		key = "testKeySuccess"
+		key := "testKeySuccess"
 
 		// Create a key
 		{
@@ -68,7 +67,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("KeyRevision", func(t *testing.T) {
 		g := NewWithT(t)
-		key = "testKeyRevision"
+		key := "testKeyRevision"
 		var lastModRev int64
 
 		// Create a key with a known value
@@ -147,7 +146,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("FailNotFound", func(t *testing.T) {
 		g := NewWithT(t)
-		key = "testKeyFailNotFound"
+		key := "testKeyFailNotFound"
 
 		// Delete key
 		{


### PR DESCRIPTION
### Summary.
Expanded on the few basic test for the Get operation. Newer tests include:

- Testing to fetch an empty key.
- Testing to fetch a range of non-existing key
- Testing the revision changes when upgrading.
- Testing fetching keys with common prefixes.
- Testing fetching a deleted key.
