### PR TITLE
Add unit tests and benchmarks for List() operation

### DIFF
--- a/test/list_test.go
+++ b/test/list_test.go
@@ -40,7 +40,6 @@ func TestList(t *testing.T) {
 			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
 			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
 			g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
-
 		})
 
 		t.Run("ListPrefix", func(t *testing.T) {
@@ -83,7 +82,6 @@ func TestList(t *testing.T) {
 			g.Expect(resp.Kvs).To(HaveLen(1))
 			g.Expect(resp.Header.Revision).ToNot(BeZero())
 			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/other/1")))
-
 		})
 
 		t.Run("ListRange", func(t *testing.T) {
@@ -104,9 +102,9 @@ func BenchmarkList(b *testing.B) {
 	client := newKine(b)
 	g := NewWithT(b)
 
-	rep := b.N
+	numItems := b.N
 
-	for i := 0; i < rep; i++ {
+	for i := 0; i < numItems; i++ {
 		key := fmt.Sprintf("key/%d", i)
 		resp, err := client.Txn(ctx).
 			If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
@@ -118,14 +116,13 @@ func BenchmarkList(b *testing.B) {
 		g.Expect(resp.Succeeded).To(BeTrue())
 	}
 
-	b.Run("BenchListCountKeys", func(b *testing.B) {
+	b.Run("List", func(b *testing.B) {
 		g := NewWithT(b)
-		for i := 0; i < rep; i++ {
+		for i := 0; i < b.N; i++ {
 			resp, err := client.Get(ctx, "key/", clientv3.WithPrefix())
 
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(rep))
+			g.Expect(resp.Kvs).To(HaveLen(numItems))
 		}
 	})
-
 }

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -18,7 +18,7 @@ func TestList(t *testing.T) {
 		g := NewWithT(t)
 
 		// Create some keys
-		keys := []string{"key/1", "key/2", "key/3"}
+		keys := []string{"/key/1", "/key/2", "/key/3"}
 		for _, key := range keys {
 			resp, err := client.Txn(ctx).
 				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
@@ -27,30 +27,73 @@ func TestList(t *testing.T) {
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Succeeded).To(BeTrue())
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
 		}
 
 		t.Run("ListAll", func(t *testing.T) {
 			// Get a list of all the keys
-			resp, err := client.Get(ctx, "", clientv3.WithPrefix())
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(0))
-		})
-
-		t.Run("ListPrefix", func(t *testing.T) {
-			// Get a list of all the keys sice they have same prefix
-			resp, err := client.Get(ctx, "key", clientv3.WithPrefix())
+			resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(HaveLen(3))
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
+			g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
+
+		})
+
+		t.Run("ListPrefix", func(t *testing.T) {
+			// Create some keys
+			keys := []string{"key/sub/1", "key/sub/2", "key/other/1"}
+			for _, key := range keys {
+				resp, err := client.Txn(ctx).
+					If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+					Then(clientv3.OpPut(key, "value")).
+					Commit()
+
+				g.Expect(err).To(BeNil())
+				g.Expect(resp.Succeeded).To(BeTrue())
+				g.Expect(resp.Header.Revision).ToNot(BeZero())
+			}
+
+			// Get a list of all the keys sice they have '/key' prefix
+			resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(3))
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
+			g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
+
+			// Get a list of all the keys sice they have '/key/sub' prefix
+			resp, err = client.Get(ctx, "key/sub", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(2))
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/sub/1")))
+			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("key/sub/2")))
+
+			// Get a list of all the keys sice they have '/key/other' prefix
+			resp, err = client.Get(ctx, "key/other", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(1))
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/other/1")))
+
 		})
 
 		t.Run("ListRange", func(t *testing.T) {
 			// Get a list of with key/1, as only key/1 falls within the specified range.
-			resp, err := client.Get(ctx, "key/1", clientv3.WithRange(""))
+			resp, err := client.Get(ctx, "/key/1", clientv3.WithRange(""))
 
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(HaveLen(1))
+			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
 		})
 	})
 }
@@ -61,8 +104,10 @@ func BenchmarkList(b *testing.B) {
 	client := newKine(b)
 	g := NewWithT(b)
 
-	for i := 0; i < b.N; i++ {
-		key := fmt.Sprintf("key-%d", i)
+	rep := b.N
+
+	for i := 0; i < rep; i++ {
+		key := fmt.Sprintf("key/%d", i)
 		resp, err := client.Txn(ctx).
 			If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
 			Then(clientv3.OpPut(key, "benchValue")).
@@ -72,4 +117,15 @@ func BenchmarkList(b *testing.B) {
 		g.Expect(err).To(BeNil())
 		g.Expect(resp.Succeeded).To(BeTrue())
 	}
+
+	b.Run("BenchListCountKeys", func(b *testing.B) {
+		g := NewWithT(b)
+		for i := 0; i < rep; i++ {
+			resp, err := client.Get(ctx, "key/", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(rep))
+		}
+	})
+
 }

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -1,0 +1,75 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestList is the unit test for List operation.
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	client := newKine(t)
+
+	t.Run("ListSuccess", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create some keys
+		keys := []string{"key1", "key2", "key3"}
+		for _, key := range keys {
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpPut(key, "value")).
+				Commit()
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+
+		t.Run("ListAll", func(t *testing.T) {
+			// Get a list of all the keys
+			resp, err := client.Get(ctx, "", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(0))
+		})
+
+		t.Run("ListPrefix", func(t *testing.T) {
+			// Get a list of all the keys sice they have same prefix
+			resp, err := client.Get(ctx, "key", clientv3.WithPrefix())
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(0))
+		})
+
+		t.Run("ListRange", func(t *testing.T) {
+			// Get a list of with key1, as only key1 falls within the specified range.
+			resp, err := client.Get(ctx, "key1", clientv3.WithRange("key2"))
+
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(0))
+		})
+	})
+}
+
+// BenchmarkList is a benchmark for the Get operation.
+func BenchmarkList(b *testing.B) {
+	ctx := context.Background()
+	client := newKine(b)
+	g := NewWithT(b)
+
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		resp, err := client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+			Then(clientv3.OpPut(key, "benchValue")).
+			Else(clientv3.OpGet(key, clientv3.WithRange(""))).
+			Commit()
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Succeeded).To(BeTrue())
+	}
+}

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -18,7 +18,7 @@ func TestList(t *testing.T) {
 		g := NewWithT(t)
 
 		// Create some keys
-		keys := []string{"key1", "key2", "key3"}
+		keys := []string{"key/1", "key/2", "key/3"}
 		for _, key := range keys {
 			resp, err := client.Txn(ctx).
 				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
@@ -42,15 +42,15 @@ func TestList(t *testing.T) {
 			resp, err := client.Get(ctx, "key", clientv3.WithPrefix())
 
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(0))
+			g.Expect(resp.Kvs).To(HaveLen(3))
 		})
 
 		t.Run("ListRange", func(t *testing.T) {
-			// Get a list of with key1, as only key1 falls within the specified range.
-			resp, err := client.Get(ctx, "key1", clientv3.WithRange("key2"))
+			// Get a list of with key/1, as only key/1 falls within the specified range.
+			resp, err := client.Get(ctx, "key/1", clientv3.WithRange(""))
 
 			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(0))
+			g.Expect(resp.Kvs).To(HaveLen(1))
 		})
 	})
 }


### PR DESCRIPTION
### Summary
Added tests and benchmarks for the list operation.
Tests include listing all, prefixed, and ranged entries. For benchmarks, we create a lot of entries and continuously evaluate their success. 