### PR TITLE
Table index migration

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -196,18 +196,6 @@ func (d *Generic) MigrateRows(txn *sql.Tx, ctx context.Context) error {
 	return nil
 }
 
-// FlushRows deletes all rows from the Kine table
-func (d *Generic) FlushRows(ctx context.Context) error {
-	logrus.Infof("Flushing kine table")
-	_, err := d.execute(ctx, `DELETE FROM kine`)
-	if err != nil {
-		logrus.Errorf("Flushing the kine table failed: %v", err)
-		return err
-	}
-
-	return nil
-}
-
 // Migrate first checks that the old key_value table and new Kine table are
 // correctly sized, and if so, it performs row migration. It's a legacy method,
 // supporting MySQL and PGSql
@@ -234,7 +222,6 @@ func (d *Generic) Migrate(ctx context.Context) {
 						WHERE kv.id IN (SELECT MAX(kvd.id) FROM key_value kvd GROUP BY kvd.name)`)
 	if err != nil {
 		logrus.Errorf("Row migrations failed: %v", err)
-
 	}
 }
 

--- a/pkg/drivers/sqlite/constants.go
+++ b/pkg/drivers/sqlite/constants.go
@@ -1,9 +1,0 @@
-package sqlite
-
-// The database version that designates whether table migration
-// from the key_value table to the Kine table has been done.
-// Databases with this version should not have the key_value table
-// present anymore, and unexpired rows of the key_value table with
-// the latest revisions must have been recorded in the Kine table
-// already
-const databaseSchemaVersion = 1

--- a/pkg/drivers/sqlite/constants.go
+++ b/pkg/drivers/sqlite/constants.go
@@ -1,0 +1,9 @@
+package sqlite
+
+// The database version that designates whether table migration
+// from the key_value table to the Kine table has been done.
+// Databases with this version should not have the key_value table
+// present anymore, and unexpired rows of the key_value table with
+// the latest revisions must have been recorded in the Kine table
+// already
+const databaseSchemaVersion = 1

--- a/pkg/drivers/sqlite/schema.go
+++ b/pkg/drivers/sqlite/schema.go
@@ -1,0 +1,76 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+)
+
+// The database version that designates whether table migration
+// from the key_value table to the Kine table has been done.
+// Databases with this version should not have the key_value table
+// present anymore, and unexpired rows of the key_value table with
+// the latest revisions must have been recorded in the Kine table
+// already
+const databaseSchemaVersion = 1
+
+// applySchemaV1 moves the schema from version 0 to version 1,
+// taking into account the possible unversioned schema from
+// upstream kine.
+func applySchemaV1(ctx context.Context, txn *sql.Tx) error {
+	if kineTableExists, err := hasTable(ctx, txn, "kine"); err != nil {
+		return err
+	} else if !kineTableExists {
+		// In this case the schema it's empty, so it is just
+		// a matter of creating the table.
+		createTableSQL := `
+CREATE TABLE kine
+(
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	created INTEGER,
+	deleted INTEGER,
+	create_revision INTEGER NOT NULL,
+	prev_revision INTEGER,
+	lease INTEGER,
+	value BLOB,
+	old_value BLOB
+)`
+
+		if _, err := txn.ExecContext(ctx, createTableSQL); err != nil {
+			return err
+		}
+	} else {
+		// The kine table already exists, so this is the case of
+		// the unversioned schema that includes the wrong indexes.
+		if _, err := txn.ExecContext(ctx, `DROP INDEX IF EXISTS kine_name_index`); err != nil {
+			return err
+		}
+		if _, err := txn.ExecContext(ctx, `DROP INDEX IF EXISTS kine_name_prev_revision_uindex`); err != nil {
+			return err
+		}
+	}
+
+	if _, err := txn.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS kine_name_index ON kine (name, id)`); err != nil {
+		return err
+	}
+
+	if _, err := txn.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (prev_revision, name)`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// hasTable checks if a table exists.
+func hasTable(ctx context.Context, txn *sql.Tx, tableName string) (bool, error) {
+	// FIXME: why we can't use `pragma_table_list()`? Is dqlite/sqlite using
+	// a very old sqlite version? `pragma_free_list()` works though...
+	tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`
+	row := txn.QueryRowContext(ctx, tableListSQL, tableName)
+	var tableCount int
+	if err := row.Scan(&tableCount); err != nil {
+		return false, err
+	}
+
+	return tableCount != 0, nil
+}

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -167,26 +167,35 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 			return fmt.Errorf("table rows could not be counted: %v", err)
 		}
 		var err error
-		for i := 0; i < 300; i++ {
-			// Clear the kine table
-			err = d.FlushRows(ctx)
-			if err != nil {
-				logrus.Errorf("failed to flush rows: %v", err)
-				continue
-			}
-			err = d.MigrateRows(ctx)
-			if err == nil {
-				break
-			}
-			logrus.Errorf("failed to migrate rows: %v", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(time.Second):
-			}
-			time.Sleep(time.Second)
-		}
+		// for i := 0; i < 300; i++ {
+		// 	// Clear the kine table
+		// 	err = d.FlushRows(ctx)
+		// 	if err != nil {
+		// 		logrus.Errorf("failed to flush rows: %v", err)
+		// 		continue
+		// 	}
+		// 	err = d.MigrateRows(ctx)
+		// 	if err == nil {
+		// 		break
+		// 	}
+		// 	logrus.Errorf("failed to migrate rows: %v", err)
+		// 	select {
+		// 	case <-ctx.Done():
+		// 		return ctx.Err()
+		// 	case <-time.After(time.Second):
+		// 	}
+		// 	time.Sleep(time.Second)
+		// }
+
+		err = d.FlushRows(ctx)
 		if err != nil {
+			logrus.Errorf("failed to flush rows: %v", err)
+			return errors.Wrap(err, "row migrations failed")
+		}
+
+		err = d.MigrateRows(ctx)
+		if err != nil {
+			logrus.Errorf("failed to migrate rows: %v", err)
 			return errors.Wrap(err, "row migrations failed")
 		}
 	}

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -6,6 +6,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"time"
 
@@ -53,6 +54,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		if err == nil {
 			break
 		}
+		fmt.Printf("failed to setup db: %v", err)
 		logrus.Errorf("failed to setup db: %v", err)
 		select {
 		case <-ctx.Done():

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
@@ -39,6 +38,13 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if err := setup(ctx, dialect.DB); err != nil {
+		msg := "failed to setup db"
+		logrus.Errorf("%s: %v", msg, err)
+		return nil, nil, errors.Wrap(err, msg)
+	}
+
 	dialect.LastInsertID = true
 	dialect.TranslateErr = func(err error) error {
 		if err, ok := err.(sqlite3.Error); ok && err.ExtendedCode == sqlite3.ErrConstraintUnique {
@@ -47,24 +53,6 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		return err
 	}
 	dialect.GetSizeSQL = `SELECT (page_count - freelist_count) * page_size FROM pragma_page_count(), pragma_page_size(), pragma_freelist_count()`
-	// this is the first SQL that will be executed on a new DB conn so
-	// loop on failure here because in the case of dqlite it could still be initializing
-	for i := 0; i < 300; i++ {
-		err = setup(dialect)
-		if err == nil {
-			break
-		}
-		logrus.Errorf("failed to setup db: %v", err)
-		select {
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		case <-time.After(time.Second):
-		}
-		time.Sleep(time.Second)
-	}
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "db table creation failed")
-	}
 
 	if err := dialect.Prepare(); err != nil {
 		return nil, nil, errors.Wrap(err, "query preparation failed")
@@ -77,171 +65,67 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 // it doesn't already exist, migrating key_value table contents to the Kine
 // table if the key_value table exists, all in a single database transaction.
 // changes are rolled back if an error occurs.
-func setup(dialect *generic.Generic) error {
-	ctx := context.Background()
-	txn, err := dialect.DB.BeginTx(ctx, nil)
+func setup(ctx context.Context, db *sql.DB) error {
+	const retryAttempts = 300
+	// Optimistically ask for the user_version without starting a transaction
+	var schemaVersion int
+
+	row := db.QueryRowContext(ctx, `PRAGMA user_version`)
+	if err := row.Scan(&schemaVersion); err != nil {
+		return err
+	}
+
+	if schemaVersion == databaseSchemaVersion {
+		return nil
+	}
+
+	txn, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer txn.Rollback()
 
-	if err := migration(ctx, txn, dialect); err != nil {
-		return errors.Wrap(err, "migration failed")
+	for i := 0; i < retryAttempts; i++ {
+		if err := migrate(ctx, txn); err != nil {
+			if sqliteErr, ok := err.(sqlite3.Error); ok && sqliteErr.ExtendedCode == sqlite3.ErrBusySnapshot {
+				// Another write transaction got in the way (SERIALIZABLE isolation).
+				// The whole transaction can be retried.
+				continue
+			}
+			return errors.Wrap(err, "migration failed")
+		}
+		break
 	}
 
 	return txn.Commit()
 }
 
-func createKineTable(txn *sql.Tx) error {
-	createTableSQL := `CREATE TABLE IF NOT EXISTS kine
-			(
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				name TEXT NOT NULL,
-				created INTEGER,
-				deleted INTEGER,
-				create_revision INTEGER NOT NULL,
-				prev_revision INTEGER,
-				lease INTEGER,
-				value BLOB,
-				old_value BLOB
-			)`
-
-	_, err := txn.Exec(createTableSQL)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// removeTable drops the table with the given name, in the given transaction.
-func removeTable(txn *sql.Tx, tableName string) error {
-	dropTableSQL := fmt.Sprintf(`DROP TABLE IF EXISTS %s`, tableName)
-	_, err := txn.Exec(dropTableSQL)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// alterIndices drops the given old database indices and creates
-// the given new ones.
-func alterIndices(txn *sql.Tx, d *generic.Generic) error {
-	if d.LockWrites {
-		d.Lock()
-		defer d.Unlock()
-	}
-
-	dropIndices := []string{
-		`DROP INDEX IF EXISTS kine_name_index`,
-		`DROP INDEX IF EXISTS kine_name_prev_revision_uindex`,
-	}
-
-	// Drop the old indices
-	for _, stmt := range dropIndices {
-		_, err := txn.Exec(stmt)
-		if err != nil {
-			return err
-		}
-	}
-
-	createIndices := []string{
-		`CREATE INDEX IF NOT EXISTS kine_name_index ON kine (name, id)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (prev_revision, name)`,
-	}
-
-	// Create the new indices
-	for _, stmt := range createIndices {
-		_, err := txn.Exec(stmt)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// countTable counts the number of tables with the given name, in the given transaction.
-func hasTable(ctx context.Context, txn *sql.Tx, tableName string) (bool, error) {
-	tableListSQL := fmt.Sprintf(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '%s'`, tableName)
-	row := txn.QueryRowContext(ctx, tableListSQL)
-	var tableCount int
-	if err := row.Scan(&tableCount); err != nil {
-		return false, err
-	}
-
-	return tableCount != 0, nil
-}
-
-// migration copies rows of the old key value table to the kine
-// table ONLY IF the key value table exists and migration has not been
-// done already. It creates the kine table if it doesn't exist.
-func migration(ctx context.Context, txn *sql.Tx, d *generic.Generic) error {
-	userVersionSQL := `PRAGMA user_version`
-	row := txn.QueryRowContext(ctx, userVersionSQL)
-
+// migrate tries to migrate from a version of the database
+// to the target one.
+func migrate(ctx context.Context, txn *sql.Tx) error {
 	var userVersion int
+
+	row := txn.QueryRowContext(ctx, `PRAGMA user_version`)
 	if err := row.Scan(&userVersion); err != nil {
 		return err
 	}
-	// No need for migration - marker has already been set
-	if userVersion == databaseSchemaVersion {
-		return nil
-	}
 
-	if userVersion > databaseSchemaVersion {
+	switch userVersion {
+	case 0:
+		if err := applySchemaV1(ctx, txn); err != nil {
+			return err
+		}
+		fallthrough
+	case databaseSchemaVersion:
+		break
+	default:
+		// FIXME this needs better handling
 		return errors.Errorf("unsupported version: %d", userVersion)
 	}
 
-	kineTableExists, err := hasTable(ctx, txn, "kine")
-	if err != nil {
+	setUserVersionSQL := fmt.Sprintf(`PRAGMA user_version = %d`, databaseSchemaVersion)
+	if _, err := txn.ExecContext(ctx, setUserVersionSQL); err != nil {
 		return err
-	}
-	// Create Kine table if it doesn't already exist
-	if !kineTableExists {
-		if err := createKineTable(txn); err != nil {
-			return err
-		}
-	}
-
-	kvTableExists, err := hasTable(ctx, txn, "key_value")
-	if err != nil {
-		return err
-	}
-	// If the key_value table exists, perform migration from key_value table to kine table
-	if kvTableExists {
-		if err := d.CheckTableRowCounts(txn, ctx); err != nil {
-			msg := "table row count issue before migration"
-			logrus.Errorf("%s: %v", msg, err)
-			return errors.Wrap(err, msg)
-		}
-
-		if err := d.MigrateRows(txn, ctx); err != nil {
-			msg := "failed to migrate rows"
-			logrus.Errorf("%s: %v", msg, err)
-			return errors.Wrap(err, msg)
-		}
-
-		if err := removeTable(txn, "key_value"); err != nil {
-			msg := "unable to remove key_value table during migration"
-			logrus.Errorf("%s: %v", msg, err)
-			return errors.Wrap(err, msg)
-		}
-	}
-
-	if err := alterIndices(txn, d); err != nil {
-		msg := "index changes failed during migration"
-		logrus.Errorf("%s: %v", msg, err)
-		return errors.Wrap(err, msg)
-	}
-
-	setUserVersionSQL := `PRAGMA user_version = 1`
-	_, err = txn.ExecContext(ctx, setUserVersionSQL)
-	if err != nil {
-		msg := "version setting failed during migration"
-		logrus.Errorf("%s: %v", msg, err)
-		return errors.Wrap(err, msg)
 	}
 
 	return nil

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -52,7 +52,7 @@ var (
 
 	userVersionSQL    = `PRAGMA user_version`
 	setUserVersionSQL = `PRAGMA user_version = 1`
-	tableListSQL      = `SELECT COUNT(*) PRAGMA table_list('key_value')`
+	tableListSQL      = `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`
 )
 
 func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
@@ -78,7 +78,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 			return server.ErrKeyExists
 		}
 		return err
-	}	
+	}
 	dialect.GetSizeSQL = `SELECT (page_count - freelist_count) * page_size FROM pragma_page_count(), pragma_page_size(), pragma_freelist_count()`
 	// this is the first SQL that will be executed on a new DB conn so
 	// loop on failure here because in the case of dqlite it could still be initializing
@@ -102,7 +102,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 	//	return nil, nil, errors.Wrap(err, "setup db")
 	//}
 
-	if err := checkMigrate(context.Background(), dialect); err != nil {		
+	if err := checkMigrate(context.Background(), dialect); err != nil {
 		return nil, nil, err
 	}
 
@@ -124,7 +124,7 @@ func setup(db *sql.DB) error {
 	return nil
 }
 
-// alterTableIndices drops the given old table indices from the existing 
+// alterTableIndices drops the given old table indices from the existing
 // kine table, and creates the given new ones.
 func alterTableIndices(d *generic.Generic) error {
 	if d.LockWrites {
@@ -151,8 +151,8 @@ func alterTableIndices(d *generic.Generic) error {
 	return nil
 }
 
-// checkMigrate performs migration from an old key value table to the kine 
-// table only if the old key value table exists and migration has not been 
+// checkMigrate performs migration from an old key value table to the kine
+// table only if the old key value table exists and migration has not been
 // done already.
 func checkMigrate(ctx context.Context, d *generic.Generic) error {
 	row := d.DB.QueryRowContext(ctx, userVersionSQL)
@@ -173,7 +173,7 @@ func checkMigrate(ctx context.Context, d *generic.Generic) error {
 	row = d.DB.QueryRowContext(ctx, tableListSQL)
 
 	var tableCount int
-	if err := row.Scan(&tableCount); err != nil {		
+	if err := row.Scan(&tableCount); err != nil {
 		if err == sql.ErrNoRows {
 			return fmt.Errorf("migrate: cannot get key_value table")
 		}

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -167,6 +167,18 @@ func countTables(ctx context.Context, db *sql.DB) (error, int) {
 	return nil, count
 }
 
+func tableNames(ctx context.Context, db *sql.DB) (error, []string) {
+	// Check if the key_value table exists
+	tableNamesSQL := `SELECT name FROM sqlite_master WHERE type = 'table'`
+	row := db.QueryRowContext(ctx, tableNamesSQL)
+	var tableNames []string
+	if err := row.Scan(&tableNames); err != nil {
+		return err, []string{}
+	}
+
+	return nil, tableNames
+}
+
 func countTable(ctx context.Context, db *sql.DB, tableName string) (error, int) {
 	// Check if the key_value table exists
 	tableListSQL := fmt.Sprintf(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '%s'`, tableName)
@@ -201,6 +213,9 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	_, allTables := countTables(context.Background(), d.DB)
 	fmt.Printf("all tables count :%d\n", allTables)
 
+	_, names := tableNames(context.Background(), d.DB)
+	fmt.Printf("all tables count :%v\n", names)
+
 	_, kineTable := countTable(context.Background(), d.DB, "kine")
 	fmt.Printf("kine table count :%d\n", kineTable)
 
@@ -212,7 +227,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	// if err := row.Scan(&tableCount); err != nil {
 	// 	return err
 	// }
-	fmt.Printf("table count :%d\n", tableCount)
+	fmt.Printf("key_value table count :%d\n", tableCount)
 
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -155,7 +155,7 @@ func alterTableIndices(d *generic.Generic) error {
 	return nil
 }
 
-func callTables(ctx context.Context, db *sql.DB) (error, int) {
+func countTables(ctx context.Context, db *sql.DB) (error, int) {
 	// Check if the key_value table exists
 	allTablesSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'`
 	row := db.QueryRowContext(ctx, allTablesSQL)
@@ -198,7 +198,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 
 	fmt.Printf("user version pass\n")
 
-	_, allTables := callTables(context.Background(), d.DB)
+	_, allTables := countTables(context.Background(), d.DB)
 	fmt.Printf("all tables count :%d\n", allTables)
 
 	// Check if the key_value table exists

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -165,9 +165,11 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	if userVersion == 1 {
-		return nil
-	}
+	// if userVersion == 1 {
+	// 	return nil
+	// }
+
+	fmt.Printf("migrate happening")
 
 	// Check if the key_value table exists
 	tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -186,11 +186,11 @@ func migration(ctx context.Context, txn *sql.Tx, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	if userVersion == 1 {
+	if userVersion == databaseSchemaVersion {
 		return nil
 	}
 
-	if userVersion > 1 {
+	if userVersion > databaseSchemaVersion {
 		return errors.Errorf("unsupported version: %d", userVersion)
 	}
 

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -152,6 +152,18 @@ func alterTableIndices(d *generic.Generic) error {
 	return nil
 }
 
+func countTable(ctx context.Context, db *sql.DB, tableName string) error {
+	// Check if the key_value table exists
+	tableListSQL := fmt.Sprintf(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '%s'`, tableName)
+	row := db.QueryRowContext(ctx, tableListSQL)
+	var tableCount int
+	if err := row.Scan(&tableCount); err != nil {
+		return err
+	}
+
+	fmt.Printf("table count :%d", tableCount)
+}
+
 // checkMigrate performs migration from an old key value table to the kine
 // table only if the old key value table exists and migration has not been
 // done already.
@@ -165,9 +177,9 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	// if userVersion == 1 {
-	// 	return nil
-	// }
+	if userVersion == 1 {
+		return nil
+	}
 
 	fmt.Printf("user version pass")
 
@@ -178,8 +190,10 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	if err := row.Scan(&tableCount); err != nil {
 		return err
 	}
-
 	fmt.Printf("table count :%d", tableCount)
+
+	fmt.Printf("number of tables: %d", countTable(ctx, d.DB, "kine"))
+
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {
 		fmt.Printf("CheckTableRowCounts")

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -164,8 +164,6 @@ func countTable(ctx context.Context, db *sql.DB, tableName string) (error, int) 
 		return err, 0
 	}
 
-	fmt.Printf("table count :%d", tableCount)
-
 	return nil, tableCount
 }
 
@@ -182,19 +180,20 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	if userVersion == 1 {
-		return nil
-	}
+	// if userVersion == 1 {
+	// 	return nil
+	// }
 
 	fmt.Printf("user version pass")
 
 	// Check if the key_value table exists
-	tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`
-	row = d.DB.QueryRowContext(ctx, tableListSQL)
-	var tableCount int
-	if err := row.Scan(&tableCount); err != nil {
-		return err
-	}
+	_, tableCount := countTable(context.Background(), d.DB, "key_value")
+	// tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`
+	// row = d.DB.QueryRowContext(ctx, tableListSQL)
+	// var tableCount int
+	// if err := row.Scan(&tableCount); err != nil {
+	// 	return err
+	// }
 	fmt.Printf("table count :%d", tableCount)
 
 	// Perform migration from key_value table to kine table

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -65,6 +65,10 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		return nil, nil, errors.Wrap(err, "db table creation failed")
 	}
 
+	if err := doMigrate(context.Background(), dialect); err != nil {
+		return nil, nil, errors.Wrap(err, "migration failed")
+	}
+
 	if err := dialect.Prepare(); err != nil {
 		return nil, nil, errors.Wrap(err, "query preparation failed")
 	}
@@ -77,9 +81,9 @@ func setup(dialect *generic.Generic) error {
 		return err
 	}
 
-	if err := doMigrate(context.Background(), dialect); err != nil {
-		return errors.Wrap(err, "migration failed")
-	}
+	// if err := doMigrate(context.Background(), dialect); err != nil {
+	// 	return errors.Wrap(err, "migration failed")
+	// }
 
 	return nil
 }

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -201,6 +201,9 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	_, allTables := countTables(context.Background(), d.DB)
 	fmt.Printf("all tables count :%d\n", allTables)
 
+	_, kineTable := countTable(context.Background(), d.DB, "kine")
+	fmt.Printf("kine table count :%d\n", kineTable)
+
 	// Check if the key_value table exists
 	_, tableCount := countTable(context.Background(), d.DB, "key_value")
 	// tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -52,6 +52,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 	for i := 0; i < 300; i++ {
 		err = setup(dialect)
 		if err == nil {
+			fmt.Printf("DB setup successful")
 			break
 		}
 		fmt.Printf("failed to setup db: %v", err)
@@ -91,6 +92,7 @@ func setup(dialect *generic.Generic) error {
 }
 
 func createTable(db *sql.DB) error {
+	fmt.Printf("Create Table")
 	createTableSQL := `CREATE TABLE IF NOT EXISTS kine
 			(
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -154,6 +156,7 @@ func alterTableIndices(d *generic.Generic) error {
 // table only if the old key value table exists and migration has not been
 // done already.
 func doMigrate(ctx context.Context, d *generic.Generic) error {
+	fmt.Printf("do migrate")
 	userVersionSQL := `PRAGMA user_version`
 	row := d.DB.QueryRowContext(ctx, userVersionSQL)
 

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -84,7 +84,8 @@ func setup(dialect *generic.Generic) error {
 		return err
 	}
 
-	fmt.Printf("number of tables: %d", countTable(context.Background(), dialect.DB, "kine"))
+	_, count := countTable(context.Background(), dialect.DB, "kine")
+	fmt.Printf("number of tables: %d", count)
 
 	if err := doMigrate(context.Background(), dialect); err != nil {
 		return errors.Wrap(err, "migration failed")
@@ -154,18 +155,18 @@ func alterTableIndices(d *generic.Generic) error {
 	return nil
 }
 
-func countTable(ctx context.Context, db *sql.DB, tableName string) error {
+func countTable(ctx context.Context, db *sql.DB, tableName string) (error, int) {
 	// Check if the key_value table exists
 	tableListSQL := fmt.Sprintf(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '%s'`, tableName)
 	row := db.QueryRowContext(ctx, tableListSQL)
 	var tableCount int
 	if err := row.Scan(&tableCount); err != nil {
-		return err
+		return err, 0
 	}
 
 	fmt.Printf("table count :%d", tableCount)
 
-	return nil
+	return nil, tableCount
 }
 
 // checkMigrate performs migration from an old key value table to the kine

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -49,6 +49,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 	dialect.GetSizeSQL = `SELECT (page_count - freelist_count) * page_size FROM pragma_page_count(), pragma_page_size(), pragma_freelist_count()`
 	// this is the first SQL that will be executed on a new DB conn so
 	// loop on failure here because in the case of dqlite it could still be initializing
+	fmt.Printf("Loop to create table\n")
 	for i := 0; i < 300; i++ {
 		err = createTable(dialect.DB)
 		if err == nil {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -165,11 +165,11 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	// if userVersion == 1 {
-	// 	return nil
-	// }
+	if userVersion == 1 {
+		return nil
+	}
 
-	fmt.Printf("migrate happening")
+	fmt.Printf("user version pass")
 
 	// Check if the key_value table exists
 	tableListSQL := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'key_value'`
@@ -179,6 +179,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 
+	fmt.Printf("table count :%d", tableCount)
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {
 		fmt.Printf("CheckTableRowCounts")

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -199,6 +199,10 @@ func migration(txn *sql.Tx, ctx context.Context, d *generic.Generic) error {
 		return nil
 	}
 
+	if userVersion > 1 {
+		return errors.Errorf("unsupported version: %d", userVersion)
+	}
+
 	tableCount, _ := countTable(txn, ctx, "key_value")
 	// If the key_value table exists, perform migration from key_value table to kine table
 	if tableCount > 0 {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -165,9 +165,9 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	// No need for migration - marker has already been set
-	if userVersion == 1 {
-		return nil
-	}
+	// if userVersion == 1 {
+	// 	return nil
+	// }
 
 	fmt.Printf("user version pass")
 

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -67,9 +67,9 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		return nil, nil, errors.Wrap(err, "db table creation failed")
 	}
 
-	if err := doMigrate(context.Background(), dialect); err != nil {
-		return nil, nil, errors.Wrap(err, "migration failed")
-	}
+	// if err := doMigrate(context.Background(), dialect); err != nil {
+	// 	return nil, nil, errors.Wrap(err, "migration failed")
+	// }
 
 	if err := dialect.Prepare(); err != nil {
 		return nil, nil, errors.Wrap(err, "query preparation failed")
@@ -83,9 +83,9 @@ func setup(dialect *generic.Generic) error {
 		return err
 	}
 
-	// if err := doMigrate(context.Background(), dialect); err != nil {
-	// 	return errors.Wrap(err, "migration failed")
-	// }
+	if err := doMigrate(context.Background(), dialect); err != nil {
+		return errors.Wrap(err, "migration failed")
+	}
 
 	return nil
 }
@@ -176,12 +176,14 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {
+		fmt.Printf("CheckTableRowCounts")
 		if err := d.CheckTableRowCounts(ctx); err != nil {
 			msg := "table rows could not be counted during migration"
 			logrus.Errorf("%s: %v", msg, err)
 			return errors.Wrap(err, msg)
 		}
 
+		fmt.Printf("MigrateRows")
 		err := d.MigrateRows(ctx)
 		if err != nil {
 			msg := "failed to migrate rows"

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -78,6 +78,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 }
 
 func createTable(db *sql.DB) error {
+	fmt.Printf("Table creation\n")
 	createTableSQL := `CREATE TABLE IF NOT EXISTS kine
 			(
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -141,6 +142,7 @@ func alterTableIndices(d *generic.Generic) error {
 // table only if the old key value table exists and migration has not been
 // done already.
 func doMigrate(ctx context.Context, d *generic.Generic) error {
+	fmt.Printf("doMigrate()\n")
 	userVersionSQL := `PRAGMA user_version`
 	row := d.DB.QueryRowContext(ctx, userVersionSQL)
 
@@ -186,13 +188,14 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		// 	}
 		// 	time.Sleep(time.Second)
 		// }
-
+		fmt.Printf("Flushing rows\n")
 		err = d.FlushRows(ctx)
 		if err != nil {
 			logrus.Errorf("failed to flush rows: %v", err)
 			return errors.Wrap(err, "row migrations failed")
 		}
 
+		fmt.Printf("Migrating rows\n")
 		err = d.MigrateRows(ctx)
 		if err != nil {
 			logrus.Errorf("failed to migrate rows: %v", err)
@@ -200,6 +203,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		}
 	}
 
+	fmt.Printf("Calling alterTableIndices()\n")
 	if err := alterTableIndices(d); err != nil {
 		return fmt.Errorf("migration failed: %v", err)
 	}
@@ -209,6 +213,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	if err != nil {
 		return fmt.Errorf("migration failed: %v", err)
 	}
+	fmt.Printf("Migration complete\n")
 
 	return nil
 }

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -171,7 +171,7 @@ func countTable(ctx context.Context, db *sql.DB, tableName string) (error, int) 
 // table only if the old key value table exists and migration has not been
 // done already.
 func doMigrate(ctx context.Context, d *generic.Generic) error {
-	fmt.Printf("do migrate")
+	fmt.Printf("do migrate\n")
 	userVersionSQL := `PRAGMA user_version`
 	row := d.DB.QueryRowContext(ctx, userVersionSQL)
 
@@ -184,7 +184,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	// 	return nil
 	// }
 
-	fmt.Printf("user version pass")
+	fmt.Printf("user version pass\n")
 
 	// Check if the key_value table exists
 	_, tableCount := countTable(context.Background(), d.DB, "key_value")
@@ -194,7 +194,7 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 	// if err := row.Scan(&tableCount); err != nil {
 	// 	return err
 	// }
-	fmt.Printf("table count :%d", tableCount)
+	fmt.Printf("table count :%d\n", tableCount)
 
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -162,6 +162,8 @@ func countTable(ctx context.Context, db *sql.DB, tableName string) error {
 	}
 
 	fmt.Printf("table count :%d", tableCount)
+
+	return nil
 }
 
 // checkMigrate performs migration from an old key value table to the kine

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -84,6 +84,8 @@ func setup(dialect *generic.Generic) error {
 		return err
 	}
 
+	fmt.Printf("number of tables: %d", countTable(context.Background(), dialect.DB, "kine"))
+
 	if err := doMigrate(context.Background(), dialect); err != nil {
 		return errors.Wrap(err, "migration failed")
 	}
@@ -193,8 +195,6 @@ func doMigrate(ctx context.Context, d *generic.Generic) error {
 		return err
 	}
 	fmt.Printf("table count :%d", tableCount)
-
-	fmt.Printf("number of tables: %d", countTable(ctx, d.DB, "kine"))
 
 	// Perform migration from key_value table to kine table
 	if tableCount > 0 {

--- a/pkg/drivers/sqlite/sqlite_test.go
+++ b/pkg/drivers/sqlite/sqlite_test.go
@@ -1,0 +1,72 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/rancher/kine/pkg/drivers/sqlite"
+)
+
+func setupV0(db *sql.DB) error {
+
+	// Create the very old key_value table
+	if _, err := db.Exec(`
+CREATE TABLE IF NOT EXISTS kine
+(
+	id INTEGER primary key autoincrement,
+	name INTEGER,
+	created INTEGER,
+	deleted INTEGER,
+	prev_revision INTEGER,
+	ttl INTEGER,
+	value BLOB,
+	old_value BLOB
+)`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestMigration(t *testing.T) {
+	const driver = "sqlite3"
+
+	folder, err := os.MkdirTemp("", "kine_test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+
+	dbPath := path.Join(folder, "db.sqlite")
+	db, err := sql.Open(driver, dbPath)
+	defer db.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setupV0(db)
+
+	ctx := context.Background()
+	if _, err := sqlite.New(ctx, dbPath); err != nil {
+		t.Fatal(err)
+	}
+
+	row := db.QueryRow(`
+SELECT COUNT(*)
+FROM sqlite_master
+WHERE type = 'index'
+	AND tbl_name = 'kine'
+	AND name IN ('kine_name_index', 'kine_name_prev_revision_uindex')`)
+
+	var indexes int
+	if err := row.Scan(&indexes); err != nil {
+		t.Error(err)
+	}
+
+	if indexes != 2 {
+		t.Errorf("Expected 2 indexes, got %d", indexes)
+	}
+}


### PR DESCRIPTION
This PR adds logic to change table indices by first dropping the old ones and then adding the new ones. It sets `user_version` with a `PRAGMA` call to mark this operation has been done. This marker is what is checked first before attempting to perform the index changes; which ensures that index changes happen only once.